### PR TITLE
improving dropdown for recipe ingredients

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -8,7 +8,6 @@
   // font-size: 18px; // font-size: 26px
 }
 
-
 html,body { height: 100%; margin: 0px; padding: 0px; }
 
 // body {

--- a/app/controllers/ingredients_controller.rb
+++ b/app/controllers/ingredients_controller.rb
@@ -43,7 +43,7 @@ class IngredientsController < ApplicationController
   private
 
   def recipe_ingredient_params
-    params.require(:recipe_ingredient).permit(:portion_id, :amount_in_measure, :measure)
+    params.require(:recipe_ingredient).permit(:portion_name, :amount_in_measure, :measure)
   end
 
   def find_ingredient

--- a/app/decorators/portion_decorator.rb
+++ b/app/decorators/portion_decorator.rb
@@ -22,6 +22,10 @@ class PortionDecorator < Draper::Decorator
   end
 
   def self.portions_collection
+    portions_collection_with_id.map(&:first)
+  end
+
+  def self.portions_collection_with_id
     Portion.ordered_by_nutrition_name_and_amount.map { |portion| [portion.decorate.name_for_dropdown, portion.id] }
   end
 end

--- a/app/forms/recipe_ingredient_form.rb
+++ b/app/forms/recipe_ingredient_form.rb
@@ -4,20 +4,21 @@ class RecipeIngredientForm
 
   delegate :persisted?, :id, to: :ingredient
 
-  attr_reader :recipe, :ingredient, :portion_id, :measure, :amount_in_measure
+  attr_reader :ingredient, :portion_name, :portion_id, :measure, :amount_in_measure
 
-  validates :portion_id, presence: true
+  validates :portion_name, presence: true
   validates :amount_in_measure, presence: true, numericality: { greater_than: 0 }
   validates :measure, presence: true
+  validate :portion_name_exists
 
   validate :portion_exists?
 
   def initialize(args = {})
-    @ingredient         = args[:ingredient]
-    @recipe             = @ingredient.recipe
-    @portion_id         = args[:portion_id] || ingredient.portion&.id
-    @measure            = args[:measure] || ingredient.measure
-    @amount_in_measure  = args[:amount_in_measure] || to_amount_in_measure(ingredient.amount)
+    @ingredient           = args[:ingredient]
+    @portion_name         = args[:portion_name] || find_portion_name_by_id(ingredient.portion&.id)
+    @portion_id           = find_portion_id_by_name(portion_name) || ingredient.portion&.id
+    @measure              = args[:measure] || ingredient.measure
+    @amount_in_measure    = args[:amount_in_measure] || to_amount_in_measure(ingredient.amount)
   end
 
   def values
@@ -42,6 +43,10 @@ class RecipeIngredientForm
 
   private
 
+  def recipe
+    @recipe ||= ingredient.recipe
+  end
+
   def portion_exists?
     find_portion.present?
   end
@@ -62,5 +67,23 @@ class RecipeIngredientForm
 
   def measure_in_pieces?
     measure == 'piece'
+  end
+
+  def find_portion_name_by_id(id)
+    PortionDecorator.portions_collection_with_id
+                    .find { |element| element.last == id}
+                    &.first
+  end
+
+  def find_portion_id_by_name(portion_name)
+    PortionDecorator.portions_collection_with_id
+                    .find { |element| element.first == portion_name}
+                    &.last
+  end
+
+  def portion_name_exists
+    if find_portion_id_by_name(portion_name).nil?
+      errors.add(:portion_name, 'does not exist')
+    end
   end
 end

--- a/app/views/ingredients/_form.html.haml
+++ b/app/views/ingredients/_form.html.haml
@@ -1,5 +1,10 @@
 = simple_form_for form, url: form.action_url do |f|
-  = f.input :portion_id, collection: PortionDecorator.portions_collection
+  = f.input :portion_name, input_html: { list: :portion_id_list }
+  %datalist#portion_id_list
+    = options_for_select PortionDecorator.portions_collection
+
+  = f.input :portion_id, as: :hidden
+
   = f.input :amount_in_measure, label: 'Amount'
   = f.input :measure, collection: IngredientsDecorator.measures_collection, include_blank: false
 

--- a/test/controllers/ingredients_controller_test.rb
+++ b/test/controllers/ingredients_controller_test.rb
@@ -14,7 +14,7 @@ class IngredientsControllerTest < ActionDispatch::IntegrationTest
       post recipe_ingredients_path(recipe),
         params: {
           recipe_ingredient: {
-            portion_id: portion.id,
+            portion_name: 'Sugar Cube (25g)',
             amount_in_measure: '1.77',
             measure: 'piece'
           }
@@ -36,7 +36,7 @@ class IngredientsControllerTest < ActionDispatch::IntegrationTest
       post recipe_ingredients_path(recipe),
         params: {
           recipe_ingredient: {
-            portion_id: portion.id,
+            portion_name: 'Milk (100ml)',
             amount_in_measure: '100',
             measure: 'unit'
           }
@@ -56,7 +56,7 @@ class IngredientsControllerTest < ActionDispatch::IntegrationTest
       patch recipe_ingredient_path(recipe, old_ingredient),
         params: {
           recipe_ingredient: {
-            portion_id: new_ingredient_portion.id,
+            portion_name: 'Milk (100ml)',
             amount_in_measure: '100',
             measure: 'unit'
           }
@@ -75,7 +75,7 @@ class IngredientsControllerTest < ActionDispatch::IntegrationTest
       post recipe_ingredients_path(recipe),
         params: {
           recipe_ingredient: {
-            portion_id: vegan_portion.id,
+            portion_name: 'Sugar Cube (25g)',
             amount_in_measure: '1',
             measure: 'piece'
           }
@@ -95,7 +95,7 @@ class IngredientsControllerTest < ActionDispatch::IntegrationTest
       patch recipe_ingredient_path(recipe, old_ingredient),
         params: {
           recipe_ingredient: {
-            portion_id: new_ingredient_portion.id,
+            portion_name: 'Sugar Cube (25g)',
             amount_in_measure: '100',
             measure: 'unit'
           }
@@ -134,7 +134,7 @@ class IngredientsControllerTest < ActionDispatch::IntegrationTest
       patch recipe_ingredient_path(recipe, non_vegan_ingredient),
         params: {
           recipe_ingredient: {
-            portion_id: new_ingredient_portion.id,
+            portion_name: 'Peanut Butter (100g)',
             amount_in_measure: '100',
             measure: 'unit'
           }

--- a/test/forms/recipe_ingredient_form_test.rb
+++ b/test/forms/recipe_ingredient_form_test.rb
@@ -24,7 +24,7 @@ class RecipeIngredientFormTest < ActiveSupport::TestCase
 
   def sugar_with_unit_params
     {
-      portion_id: portions(:sugar_default_portion).id,
+      portion_name: 'Sugar (100g)',
       amount_in_measure: '300',
       measure: 'unit'
     }
@@ -32,7 +32,7 @@ class RecipeIngredientFormTest < ActiveSupport::TestCase
 
   def sugar_cubes_pieces_params
     {
-      portion_id: portions(:sugar_cube_portion).id,
+      portion_name: 'Sugar Cube (25g)',
       amount_in_measure: '5',
       measure: 'piece'
     }

--- a/test/integration/recipe_ingredient_flows_test.rb
+++ b/test/integration/recipe_ingredient_flows_test.rb
@@ -24,7 +24,7 @@ class RecipeIngredientFlowsTest < ActionDispatch::IntegrationTest
     post "/recipes/#{recipe.id}/ingredients",
       params: {
         recipe_ingredient: {
-          portion_id: '',
+          portion_name: '',
           amount_in_measure: '',
           measure: ''
         }
@@ -35,7 +35,7 @@ class RecipeIngredientFlowsTest < ActionDispatch::IntegrationTest
     post "/recipes/#{recipe.id}/ingredients",
       params: {
         recipe_ingredient: {
-          portion_id: ingredient_portion.id,
+          portion_name: 'Sugar (100g)',
           amount_in_measure: '500',
           measure: 'unit'
         }
@@ -52,7 +52,7 @@ class RecipeIngredientFlowsTest < ActionDispatch::IntegrationTest
     post "/recipes/#{recipe.id}/ingredients",
       params: {
         recipe_ingredient: {
-          portion_id: ingredient_portion.id,
+          portion_name: 'Sugar Cube (25g)',
           amount_in_measure: '2',
           measure: 'piece'
         }
@@ -72,7 +72,7 @@ class RecipeIngredientFlowsTest < ActionDispatch::IntegrationTest
     put "/recipes/#{ingredient.recipe.id}/ingredients/#{ingredient.id}",
       params: {
         recipe_ingredient: {
-          portion_id: ingredient.portion.id,
+          portion_id_selection: 'Milk (100ml)',
           amount_in_measure: '60',
           measure: 'unit'
         }


### PR DESCRIPTION
Before this commit the dropdown was hard to browser since it was a simple select list.

This commit introduces `<datalist>` feature so the user may start typing the ingredient and have a "free" autocomplete functionality.