### PR TITLE
replace Procfile with "release" commands

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+release: bin/rails db:migrate db:seed


### PR DESCRIPTION
Realised that DB migrations have not run in a while because they've always been executed manually. Let's change that.