### PR TITLE
fix bug when deleting last meal of a journal day

### DIFF
--- a/lib/sql/update_nutrition_facts_on_journal_days.sql
+++ b/lib/sql/update_nutrition_facts_on_journal_days.sql
@@ -13,11 +13,11 @@ with_journal_day_meal_nutrition_facts AS (
        , (m.amount / da.value) * n.fiber            AS journal_day_meal_fiber
     FROM journal_days jd
    CROSS JOIN default_amount da
-   INNER JOIN meals m      ON m.journal_day_id = jd.id
-   INNER JOIN portions p   ON p.id = m.portion_id
-   INNER JOIN nutritions n ON n.id = p.nutrition_id
+   LEFT OUTER JOIN meals m      ON m.journal_day_id = jd.id
+   LEFT OUTER JOIN portions p   ON p.id = m.portion_id
+   LEFT OUTER JOIN nutritions n ON n.id = p.nutrition_id
  ),
- 
+
  with_summed_nutrition_facts AS (
    SELECT journal_day_id
         , sum(journal_day_meal_kcal)             AS journal_day_kcal_sum
@@ -61,13 +61,13 @@ INSERT INTO journal_days (
 SELECT jd.id
      , jd.user_id
      , jd.date
-     , tnf.journal_day_target_kcal
-     , tnf.journal_day_target_carbs
-     , tnf.journal_day_target_carbs_sugar_part
-     , tnf.journal_day_target_protein
-     , tnf.journal_day_target_fat
-     , tnf.journal_day_target_fat_saturated
-     , tnf.journal_day_target_fiber
+     , COALESCE(tnf.journal_day_target_kcal, 0)             AS journal_day_target_kcal
+     , COALESCE(tnf.journal_day_target_carbs, 0)            AS journal_day_target_carbs
+     , COALESCE(tnf.journal_day_target_carbs_sugar_part, 0) AS journal_day_target_carbs_sugar_part
+     , COALESCE(tnf.journal_day_target_protein, 0)          AS journal_day_target_protein
+     , COALESCE(tnf.journal_day_target_fat, 0)              AS journal_day_target_fat
+     , COALESCE(tnf.journal_day_target_fat_saturated, 0)    AS journal_day_target_fat_saturated
+     , COALESCE(tnf.journal_day_target_fiber, 0)            AS journal_day_target_fiber
      , jd.created_at
      , NOW() AS updated_at
   FROM with_rounded_target_nutrution_facts tnf

--- a/test/services/nutrition_facts_service_test.rb
+++ b/test/services/nutrition_facts_service_test.rb
@@ -91,6 +91,25 @@ class NutritionFactsServiceTest < ActiveSupport::TestCase
     assert_equal 196, journal_day.fiber
   end
 
+  test '.update(:journal_days), no meals' do
+    journal_day = journal_days(:john_january_first)
+    journal_day.meals.delete_all
+
+    fake_nutrition_facts!(journal_day)
+
+    NutritionFactsService.update(:journal_days)
+
+    journal_day.reload
+
+    assert_equal 0, journal_day.kcal
+    assert_equal 0, journal_day.carbs
+    assert_in_delta(0, journal_day.carbs_sugar_part)
+    assert_equal 0, journal_day.protein
+    assert_equal 0, journal_day.fat
+    assert_in_delta(0, journal_day.fat_saturated)
+    assert_equal 0, journal_day.fiber
+  end
+
   private
 
   def truncate_nutrition_facts!(record)
@@ -102,6 +121,18 @@ class NutritionFactsServiceTest < ActiveSupport::TestCase
       fat: 0.0,
       fat_saturated: 0.0,
       fiber: 0.0
+    )
+  end
+
+  def fake_nutrition_facts!(record)
+    record.update!(
+      kcal: 999,
+      carbs: 999.9,
+      carbs_sugar_part: 999.9,
+      protein: 999.9,
+      fat: 999.9,
+      fat_saturated: 999.9,
+      fiber: 999.9
     )
   end
 end


### PR DESCRIPTION
After deleting the last meal of a journal day the nutrition facts were not calculated correctly because the script used a `INNER JOIN`. Not having a meal would not select the journal day anymore.

Switching to a `LEFT OUTER JOIN` and `COALESCE`-ing to `0` resolves that problem.