### PR TITLE
fix issue in recipe ingredient selection if 2 foods share the name

### DIFF
--- a/app/components/food_search_form_component.html.haml
+++ b/app/components/food_search_form_component.html.haml
@@ -18,11 +18,11 @@
   - if form.no_foods_found?
     .text-gray-500.w-full.text-sm
       No foods found
-  - elsif form.search_results.count > 1
+  - elsif form.food.new_record? && form.search_results.count > 1
     %ul.food-search-result.bg-white.rounded.divide-y.divide-gray-200.border.border-gray-200
       - form.search_results.each do |food|
         %li.p-2.flex.items-center
-          .grow
+          .food-name.grow
             = food.name
           .shrink-0
-            = link_to 'Select', url_for(food_name: food.name), class: 'border text-gray-500 rounded py-1 px-4 text-xs hover:border-gray-700 hover:text-gray-700 transition'
+            = link_to 'Select', url_for(food_id: food.id), class: 'border text-gray-500 rounded py-1 px-4 text-xs hover:border-gray-700 hover:text-gray-700 transition'

--- a/test/controllers/foods_controller_test.rb
+++ b/test/controllers/foods_controller_test.rb
@@ -37,16 +37,16 @@ class FoodsControllerTest < ActionDispatch::IntegrationTest
     assert_difference -> { users(:daisy).foods.count }, +1 do
       post foods_path, params: {
         food: {
-          name: 'Pineapple',
+          name: 'Cherries, sweet, raw',
           vegan: '1',
-          kcal: '74',
-          carbs: '19.58',
-          carbs_sugar_part: '14.35',
-          protein: '0.85',
-          fat: '0.19',
-          fat_saturated: '0.014',
-          fiber: '2.2',
-          data_source_url: 'https://fdc.nal.usda.gov/fdc-app.html#/food-details/169124/nutrients'
+          kcal: '63',
+          carbs: '16',
+          carbs_sugar_part: '12.8',
+          fiber: '2.1',
+          protein: '1.06',
+          fat: '0.2',
+          fat_saturated: '0.038',
+          data_source_url: 'https://fdc.nal.usda.gov/fdc-app.html#/food-details/171719/nutrients'
         }
       }
     end
@@ -54,8 +54,8 @@ class FoodsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     food = users(:daisy).foods.last
-    assert_equal 'Pineapple', food.name
-    assert_match(/169124/, food.data_source_url)
+    assert_equal 'Cherries, sweet, raw', food.name
+    assert_match(/171719/, food.data_source_url)
   end
 
   # edit

--- a/test/fixtures/foods.yml
+++ b/test/fixtures/foods.yml
@@ -114,3 +114,17 @@ maple_syrup:
   fiber: 0
   vegan: true
   user: john
+
+pineapple:
+  name: 'Pineapple'
+  unit: 'gram'
+  kcal: 50
+  carbs: 13.1
+  carbs_sugar_part: 9.65
+  protein: 0.54
+  fat: 0.12
+  fat_saturated: 0.009
+  fiber: 1.4
+  vegan: true
+  user: global
+  data_source_url: 'https://fdc.nal.usda.gov/fdc-app.html#/food-details/169124/nutrients'

--- a/test/fixtures/portions.yml
+++ b/test/fixtures/portions.yml
@@ -177,3 +177,27 @@ maple_syrup_tablespoon_portion:
   fat: 0.012
   fat_saturated: 0.001
   fiber: 0
+
+pineapple_default_portion:
+  name: '100g'
+  food: pineapple
+  amount: 100
+  kcal: 50
+  carbs: 13.1
+  carbs_sugar_part: 9.65
+  protein: 0.54
+  fat: 0.12
+  fat_saturated: 0.009
+  fiber: 1.4
+
+pineapple_fruit_portion:
+  name: 'Fruit'
+  food: pineapple
+  amount: 905
+  kcal: 453
+  carbs: 119
+  carbs_sugar_part: 89.1
+  protein: 4.89
+  fat: 1.09
+  fat_saturated: 0.081
+  fiber: 12.7

--- a/test/forms/food_search_form_test.rb
+++ b/test/forms/food_search_form_test.rb
@@ -13,13 +13,13 @@ class FoodSearchFormTest < ActiveSupport::TestCase
   end
 
   test '#food, global food, as admin' do
-    form = FoodSearchForm.new({ food_name: 'Apple', action_url: '/foo' }, users(:daisy))
-    assert_equal foods(:apple), form.food
+    form = FoodSearchForm.new({ food_name: 'Banana', action_url: '/foo' }, users(:daisy))
+    assert_equal foods(:banana), form.food
   end
 
   test '#food, global food, as user' do
-    form = FoodSearchForm.new({ food_name: 'Apple', action_url: '/foo' }, users(:john))
-    assert_equal foods(:apple), form.food
+    form = FoodSearchForm.new({ food_name: 'Banana', action_url: '/foo' }, users(:john))
+    assert_equal foods(:banana), form.food
   end
 
   test '#food, own food' do

--- a/test/system/recipe/ingredients_test.rb
+++ b/test/system/recipe/ingredients_test.rb
@@ -30,27 +30,21 @@ class Recipe::IngredientTest < ApplicationSystemTestCase
     sign_in_and_navigate_to_apple_pie_recipe
     click_on 'Add ingredient'
 
-    search_food 'na'
+    search_food 'apple'
 
-    within 'ul.food-search-result' do
-      assert_selector 'li', count: 2
-
-      assert_selector 'li', text: 'Banana' do |element|
-        element.click_on 'Select'
-      end
-    end
+    select_search_result 'Pineapple'
 
     within '.portions-select' do
-      assert_checked_field 'Banana 100'
-      choose 'Banana Regular'
+      assert_checked_field 'Pineapple 100'
+      choose 'Pineapple Fruit'
     end
 
-    fill_in 'Amount in measure', with: '5'
+    fill_in 'Amount in measure', with: '1'
     click_on 'Add ingredient'
 
-    within_recipe_ingredient('Banana Regular') do
-      assert_selector '.recipe-ingredient--quantity', text: '5'
-      assert_selector '.recipe-ingredient--amount', text: '580'
+    within_recipe_ingredient('Pineapple Fruit') do
+      assert_selector '.recipe-ingredient--quantity', text: '1'
+      assert_selector '.recipe-ingredient--amount', text: '905'
     end
   end
 
@@ -78,6 +72,7 @@ class Recipe::IngredientTest < ApplicationSystemTestCase
     search_food 'Banana'
     click_on 'Add ingredient'
     search_food 'Apple'
+    select_search_result 'Apple'
     assert_checked_field 'Apple 100' # checks if action_url works properly
   end
 
@@ -207,5 +202,15 @@ class Recipe::IngredientTest < ApplicationSystemTestCase
     title, kcal, carbs, protein, fat = find_all('.nutritions-table--totals > div').to_a.map(&:text)
 
     { title:, kcal:, carbs:, protein:, fat: }
+  end
+
+  def select_search_result(food_name)
+    within 'ul.food-search-result' do
+      assert_selector 'li', count: 2
+
+      within(find('li .food-name', text: food_name, exact_text: true).ancestor('li')) do
+        click_on 'Select'
+      end
+    end
   end
 end


### PR DESCRIPTION
Before this commit it was not possible to Select "Apple" in the Recipe Ingredient selection because "Pineapple" also includes the word "apple" and the search result was not distinct.
This commit changes the behaviour so that if a food is selected in the food search result, it is fetched by id and returns a "definite" food.